### PR TITLE
add max-parallel directive to limit load

### DIFF
--- a/.github/workflows/repo_search.yml
+++ b/.github/workflows/repo_search.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 10
       fail-fast: false
       matrix:
        search_str: 


### PR DESCRIPTION
We are frequently seeing search jobs fail with the following error:

```
github.GithubException.RateLimitExceededException: 403 {"documentation_url": "https://docs.github.com/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits", "message": "You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 9080:324B1F:C12EC:15350D:66673372."}
Error: Process completed with exit code 1.
```

This change limits the number of parallel jobs to 10, which might increase the total duration of a run but hopefully will reduce the chances of the aggregate searches hitting the secondary limit.